### PR TITLE
Add schedule, process, and toolsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The event's schedule is as follows:
 
 * 10 AM: The event starts.
 * 12 PM: Lunch.
-* 4 PM: Presentations begin.
-* 5 PM: Wrap-up.
+* 3 PM: Presentations begin.
+* 4 PM: Wrap-up.
 
-We'll have to clear out of the venue by 6 PM.
+We'll have to clear out of the venue by 5 PM.
 
 ## Process
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
 # Hackathon 2016
 
 Welcome to the API Craft SF hackathon for 2016 at GitHub!
+
+**Tables of Contents**
+
+* [Schedule](#schedule)
+* [Process](#process)
+* [API Toolsets](#api-toolsets)
+
+## Schedule
+
+The event's schedule is as follows:
+
+* 10 AM: The event starts.
+* 12 PM: Lunch.
+* 4 PM: Presentations begin.
+* 5 PM: Wrap-up.
+
+We'll have to clear out of the venue by 6 PM.
+
+## Process
+
+The Hackathon will take the following form:
+
+* Participants will split up in teams of 4. Teams can self-organize as they
+  wish, but it's suggested they pick 1-2 team members to serve as "API
+  Consumers" and the rest of the team to act as the "API Provider" (comprising
+  backend developers, API owners, architects).
+* Teams will get [one of the API toolsets](#api-toolsets) assigned to them.
+  It's strongly suggested, but not mandatory that the team uses that toolset to
+  complete the exercise.
+* Teams will attempt to improve, enhance and document the subject API in the
+  time available.
+* The scope of this exercise is the HTTP/REST API definition, documentation and
+  prototype/mock only. A server or front-end implementation is neither
+  required, nor expected. The API definition and documentation should be
+  checked in or linked to the hackathon's GitHub public repo.
+* At the end of the allotted time, teams will elect one spokesperson to present
+  their solution and one spokesperson to describe the process they used and
+  feedback on the toolset used.
+
+## API Toolsets
+
+* [Apiary](https://apiary.io/)
+* [Apigee-127](https://github.com/swagger-api/swagger-node)
+* Mulesoft
+* [Smartbear SwaggerHub](https://swaggerhub.com/)


### PR DESCRIPTION
Adds in some basic information written by Emmanuel.

A few things are currently missing:
- More specific information about how teams upload their definitions to GitHub. I can add this in after we've talked it over.
- A link to the Mulesoft tooling.

/cc @paraskakis 
